### PR TITLE
Fix typo: kay -> key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # QDBM 
-An ordered key/value database that supports transactions and arbitrary kay and value sizes.
+An ordered key/value database that supports transactions and arbitrary key and value sizes.
 
 # Installation 
 `QDBM` should be installed and foundable in your system. Then:


### PR DESCRIPTION
I love io and noticed this typo reading the docs here:

https://iolanguage.org/reference/

Not sure if this is the right source. There may be others but I'm unfamiliar with the doc source structure.